### PR TITLE
UI: Use the term "N-gon" instead of "Polygon" for triangulation method

### DIFF
--- a/dual_mesh.py
+++ b/dual_mesh.py
@@ -158,8 +158,8 @@ class dual_mesh(Operator):
                 ('BEAUTY', 'Beauty', 'Arrange the new triangles evenly'),
                 ('CLIP', 'Clip',
                  'Split the polygons with an ear clipping algorithm')],
-            name="Polygon Method",
-            description="Method for splitting the polygons into triangles",
+            name="N-gon Method",
+            description="Method for splitting the N-gons into triangles",
             default="BEAUTY",
             options={'LIBRARY_EDITABLE'}
             )


### PR DESCRIPTION
Since quads are also polygons (and quads have their own method), the
term "N-gon" is more appropriate here and is also described in the
glossary https://docs.blender.org/manual/en/2.92/glossary/index.html#term-N-gon

This is a follow up on https://developer.blender.org/rB03f1d8acab5b96321935b03f7a402455d2a91fc8