### PR TITLE
Update documentation URL to the official manual

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,7 +38,7 @@ bl_info = {
     "location": "",
     "description": "Tools for Computational Design",
     "warning": "",
-    "wiki_url": "https://github.com/alessandro-zomparelli/tissue/wiki",
+    "doc_url": "{BLENDER_MANUAL_URL}/addons/mesh/tissue.html",
     "tracker_url": "https://github.com/alessandro-zomparelli/tissue/issues",
     "category": "Mesh"}
 


### PR DESCRIPTION
Also replaces the deprecated `wiki_url` with `doc_url`.

Support for `wiki_url` has been removed in recent versions